### PR TITLE
[add]フッターに被らないようにするレイアウト

### DIFF
--- a/menu_recsys/templates/layouts/base.html
+++ b/menu_recsys/templates/layouts/base.html
@@ -5,10 +5,10 @@
     <meta charset="utf-8">
     <title>PlatePandA</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <script src="https://use.fontawesome.com/releases/v5.3.1/js/all.js" defer ></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.8.0/css/bulma.min.css" />
     <link rel="stylesheet" href="{% static 'css/head_foot.css' %}" type="text/css">
     <link rel="stylesheet" href="{% static 'css/user_home.css' %}" type="text/css">
+    <script src="https://kit.fontawesome.com/3caa0f69bb.js" crossorigin="anonymous"></script>
   </head>
 
   <body>
@@ -30,6 +30,13 @@
         </div>
      </footer>
   </body>
+
+  <style>
+    .container {
+      height: calc(100vh - 100px); /* 100vh - ヘッダーとフッターの高さ */
+      overflow: scroll;
+    }
+  </style>
 </html>
 
 


### PR DESCRIPTION
mainタグの中身が長すぎた場合、footerに被って表示されていたが、footerの下に表示内容が回り込み、スクロールすることではみ出た部分を見る仕様に変更